### PR TITLE
Update README.md with correct migration command

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Install the gem and run the migration.
 
 ```shell
 bundle add active_storage_encryption
-bin/rails active_storage_encryption:install
+bin/rails g active_storage_encryption:install
 bin/rails db:migrate
 ```
 


### PR DESCRIPTION
The readme mentions this command but without the `g` got me questioning my sanity while running the command and seeing a "Did you mean?"-error 😅 

This updates the readme, adds the `g`. The command is mentioned correctly in the source btw lib/generators/install_generator.rb:9.