### PR TITLE
Set the default active-storage service is service_name is not given

### DIFF
--- a/lib/active_storage_encryption/overrides.rb
+++ b/lib/active_storage_encryption/overrides.rb
@@ -15,6 +15,7 @@ module ActiveStorageEncryption
             ENCRYPTION_KEY_LENGTH_BYTES = 16 + 32 # So we have enough
 
             def service_encrypted?(service_name)
+              service_name ||= Rails.application.config.active_storage.service
               return false unless service_name
 
               service = ActiveStorage::Blob.services.fetch(service_name) do


### PR DESCRIPTION
Given a few models like 

```ruby
class Task < ApplicationRecord
  has_many_attached :files, service: :local
end
```

```ruby
class User < ApplicationRecord
  has_many_attached :files
end
```

and a configuration of `config.active_storage.service = :encrypted_local_disk` inside `config/environments/<environment>.rb`

this will allow a single model to provide a custom service: or use the "default" set in the rails configuration.

This fixes the issue that when a model with `attached :files` does not use a service explicitly it will default to the rails "global" service.


Haven't added any tests as I am not sure if this is _the_ solution. This works for my current use case but might not work for all. 
If this is ok I'll add some tests to make sure this works in a variety of setups.