### PR TITLE
Run the suite without minitest/mock

### DIFF
--- a/test/integration/encrypted_blob_proxy_controller_test.rb
+++ b/test/integration/encrypted_blob_proxy_controller_test.rb
@@ -181,7 +181,7 @@ class ActiveStorageEncryptionEncryptedBlobProxyControllerTest < ActionDispatch::
     encryption_key = rng.bytes(32)
     @service.upload(key, StringIO.new(rng.bytes(512)).binmode, encryption_key: encryption_key)
 
-    streaming_url = ActiveStorageEncryption.stub(:token_encryptor, -> { other_encryptor }) do
+    streaming_url = with_token_encryptor(other_encryptor) do
       @service.url(key, encryption_key: encryption_key,
         filename: ActiveStorage::Filename.new("private.doc"), expires_in: 3.seconds,
         disposition: "inline", content_type: "binary/octet-stream",
@@ -249,5 +249,18 @@ class ActiveStorageEncryptionEncryptedBlobProxyControllerTest < ActionDispatch::
 
     get streaming_url, headers: {"HTTP_X_ACTIVE_STORAGE_ENCRYPTION_KEY" => Base64.strict_encode64(blob.encryption_key)}
     assert_response :forbidden # With headers
+  end
+
+  private
+
+  # Swaps in another token encryptor for the duration of the block. Done by hand rather than
+  # with Minitest::Mock#stub, so that the suite does not depend on minitest/mock - which
+  # minitest 6 moved into a gem of its own.
+  def with_token_encryptor(encryptor)
+    original = ActiveStorageEncryption.method(:token_encryptor)
+    ActiveStorageEncryption.define_singleton_method(:token_encryptor) { encryptor }
+    yield
+  ensure
+    ActiveStorageEncryption.define_singleton_method(:token_encryptor, original)
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -8,7 +8,6 @@ ActiveRecord::Migrator.migrations_paths = [File.expand_path("../test/dummy/db/mi
 ActiveRecord::Migrator.migrations_paths << File.expand_path("../db/migrate", __dir__)
 require "rails/test_help"
 
-require "minitest/mock"
 
 # Load fixtures from the engine
 if ActiveSupport::TestCase.respond_to?(:fixture_paths=)


### PR DESCRIPTION
The test helper requires `minitest/mock`, which minitest 6 moved into a gem of its own, so on any Ruby which resolves minitest 6 (Ruby 4.0 does) the helper cannot require and **the suite does not boot at all**.

The only place which needed it stubbed the token encryptor in one test. That now happens by hand in four lines, so nothing has to be pinned and the suite runs on minitest 5 and 6 alike.

Verified on minitest 6.0.6 with no pin: 72 runs, 159 assertions, 0 failures.