### PR TITLE
Honor exclusive ranges in EncryptedDiskService#download_chunk

### DIFF
--- a/lib/active_storage_encryption/encrypted_disk_service.rb
+++ b/lib/active_storage_encryption/encrypted_disk_service.rb
@@ -60,6 +60,10 @@ module ActiveStorageEncryption
     def download_chunk(key, range, encryption_key:)
       instrument :download_chunk, key: key, range: range do
         scheme = create_scheme(key, encryption_key)
+        # The schemes only understand inclusive ranges, but ActiveStorage passes exclusive ones
+        # in places - `0...4.kilobytes` when it identifies a blob, for instance. The stock
+        # S3Service and GCSService both honour `exclude_end?`, so we have to as well.
+        range = (range.begin..(range.end - 1)) if range.exclude_end?
         File.open(path_for(key), "rb") do |file|
           scheme.decrypt_range(from_ciphertext_io: file, range:)
         end

--- a/test/lib/encrypted_disk_service_test.rb
+++ b/test/lib/encrypted_disk_service_test.rb
@@ -267,6 +267,18 @@ class ActiveStorageEncryption::EncryptedDiskServiceTest < ActiveSupport::TestCas
     assert_equal content, downloaded_blob
   end
 
+  def test_download_chunk_honors_an_exclusive_range
+    storage_blob_key = "key-1"
+    encryption_key = Random.bytes(68)
+    plaintext_upload_bytes = generate_random_binary_string
+    @service.upload(storage_blob_key, StringIO.new(plaintext_upload_bytes), encryption_key: encryption_key)
+
+    # ActiveStorage reads `0...4.kilobytes` when it identifies a blob, and the stock services
+    # return 4096 bytes for that - not 4097.
+    exclusive_range = 0...4.kilobytes
+    assert_equal plaintext_upload_bytes[exclusive_range], @service.download_chunk(storage_blob_key, exclusive_range, encryption_key: encryption_key)
+  end
+
   def generate_random_binary_string(size = 17.kilobytes + 13)
     Random.bytes(size)
   end


### PR DESCRIPTION
`download_chunk` passes the range to the scheme unchanged, and the schemes count an inclusive range (`range.end - range.begin + 1`), so an exclusive range returns one byte too many.

That is not hypothetical: ActiveStorage reads `0...4.kilobytes` when it identifies a blob, so today that call returns 4097 bytes. The stock `S3Service` and `GCSService` both honour `exclude_end?`, so the encrypted disk service is the odd one out.

One line, plus a regression test asserting the exclusive read matches the same slice of the plaintext. 73 runs, 0 failures.